### PR TITLE
Tokenizer ignores leading and trailing '\t' char

### DIFF
--- a/src/main/model/lexicalanalyzer/Tokenizer.java
+++ b/src/main/model/lexicalanalyzer/Tokenizer.java
@@ -63,7 +63,7 @@ public class Tokenizer {
                         state = LexState.LS_STRLIT1;
                     }else if (nextChar == '\n'){
                         state = LexState.LS_STOP; 
-                    }else if (nextChar != ' '){
+                    }else if (nextChar != ' ' && nextChar != '\t'){
                         aToken = new TInvalid("LS_START: Invalid character.");
                     }
                     break;
@@ -123,7 +123,7 @@ public class Tokenizer {
                     if (Util.isAlpha(nextChar)){
                         localStringValue.append(nextChar);
                         state = LexState.LS_ADDR2; 
-                    }else if (nextChar != ' '){
+                    }else if (nextChar != ' ' && nextChar != '\t'){
                         aToken = new TInvalid("LS_ADDR1: Invalid character used in adddress name. Use only alphabetical character."); 
                     }
                     break;

--- a/src/test/TokenizerTest.java
+++ b/src/test/TokenizerTest.java
@@ -344,8 +344,33 @@ public class TokenizerTest {
         AToken aToken3 = t3.getToken();
 
         assertTrue(aToken3 instanceof TSymbol);
-
-
     }
 
+    @Test
+    public void leadingTabsTest()
+    {
+        InBuffer b1 = new InBuffer("ldwa \t\t");
+        Tokenizer t1 = new Tokenizer(b1); 
+        
+        b1.getLine(); 
+        AToken aToken1 = t1.getToken();
+
+        assertTrue(aToken1 instanceof TIdentifier);
+
+        InBuffer b2 = new InBuffer(", \t d");
+        Tokenizer t2 = new Tokenizer(b2); 
+        
+        b2.getLine(); 
+        AToken aToken2 = t2.getToken();
+
+        assertTrue(aToken2 instanceof TAddress);
+
+        InBuffer b3 = new InBuffer("\t   .end\t");
+        Tokenizer t3 = new Tokenizer(b3); 
+        
+        b3.getLine(); 
+        AToken aToken3 = t3.getToken();
+
+        assertTrue(aToken3 instanceof TDotCommand);
+    }
 }

--- a/src/test/TranslatorTest.java
+++ b/src/test/TranslatorTest.java
@@ -244,4 +244,17 @@ public class TranslatorTest {
 
         assertFalse(tr03.translate());
     }
+
+    @Test
+    public void leadingTabsTest()
+    {
+        InBuffer b1 = new InBuffer("ldwa \t\t 4	, i \n" + 
+                                    "Stwa 5   , \t d \n" +
+                                    "\t   .end\t	"); 
+        Translator tr01 = new Translator(b1); 
+        Generator g01 = new Generator(tr01);
+
+        assertTrue(tr01.translate());
+        assertEquals("C0 00 04\nE1 00 05\nzz\n", g01.generateObjectCode());
+    }
 }


### PR DESCRIPTION
Addressed issue:
Ignore leading tab in tokenization #19